### PR TITLE
fixed an outdated class name on serious-eats-extract-directions

### DIFF
--- a/org-chef-serious-eats.el
+++ b/org-chef-serious-eats.el
@@ -80,7 +80,7 @@
 (defun org-chef-serious-eats-extract-directions (dom)
   "Get the directions for a recipe from an seriouseats DOM."
   (mapcar #'(lambda (n) (string-trim (dom-texts (dom-children n))))
-          (dom-by-class dom "^recipe-procedure-text$")))
+          (dom-by-class dom "^recipe-procedures$")))
 
 
 (defun org-chef-serious-eats-fetch (url)


### PR DESCRIPTION
This fixes #42. I simply changed the old class value to the new one; not sure if you need to account for both?