### PR TITLE
fix regular expression that was too strict

### DIFF
--- a/org-chef-serious-eats.el
+++ b/org-chef-serious-eats.el
@@ -80,7 +80,7 @@
 (defun org-chef-serious-eats-extract-directions (dom)
   "Get the directions for a recipe from an seriouseats DOM."
   (mapcar #'(lambda (n) (string-trim (dom-texts (dom-children n))))
-          (dom-by-class dom "^recipe-procedures$")))
+          (dom-by-class dom "^recipe-procedures")))
 
 
 (defun org-chef-serious-eats-fetch (url)


### PR DESCRIPTION
The earlier iteration assumed only one class on the element, and if more than one it failed. This correct that.